### PR TITLE
Fixes compat issue with IE11

### DIFF
--- a/js/stores/SearchResultsStore.js
+++ b/js/stores/SearchResultsStore.js
@@ -99,6 +99,9 @@ AppDispatcher.register(function(action) {
         SearchResultsStore.emitChange();
 
         search(searchQuery).then(function(response) {
+          if(typeof(response) === "string") {
+            response = JSON.parse(response);
+          }
           if (response &&
             response.PrimaryQueryResult &&
             response.PrimaryQueryResult.RelevantResults &&


### PR DESCRIPTION
In IE11 the typeof(response) is "string" but has all the right data. Parsing the response fixes the issue and maintains compatibility in other browsers
